### PR TITLE
feat: add shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,41 @@ agentree -b experiment-ml -r
 agentree rm agent/auth-system -R
 ```
 
+## Shell Completion
+
+agentree supports tab completion for commands, flags, branch names, and worktree names.
+
+### Bash
+
+```bash
+# Add to ~/.bashrc or ~/.bash_profile:
+source <(agentree completion bash)
+```
+
+### Zsh
+
+```bash
+# Add to ~/.zshrc:
+source <(agentree completion zsh)
+
+# Or for oh-my-zsh users, add to completions directory:
+agentree completion zsh > ~/.oh-my-zsh/completions/_agentree
+```
+
+### Fish
+
+```bash
+# Add to ~/.config/fish/completions/:
+agentree completion fish > ~/.config/fish/completions/agentree.fish
+```
+
+### PowerShell
+
+```powershell
+# Add to your PowerShell profile:
+agentree completion powershell | Out-String | Invoke-Expression
+```
+
 ## Development
 
 ```bash

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion script",
+	Long: `Generate a shell completion script for agentree.
+
+This command generates shell completion scripts that enable tab completion
+for agentree commands, flags, branch names, worktree names, and more.
+
+Examples:
+  # Bash (add to ~/.bashrc or ~/.bash_profile):
+  source <(agentree completion bash)
+  
+  # Zsh (add to ~/.zshrc):
+  source <(agentree completion zsh)
+  # Or for oh-my-zsh, add to ~/.oh-my-zsh/completions/:
+  agentree completion zsh > ~/.oh-my-zsh/completions/_agentree
+  
+  # Fish (add to ~/.config/fish/completions/):
+  agentree completion fish > ~/.config/fish/completions/agentree.fish
+  
+  # PowerShell (add to your PowerShell profile):
+  agentree completion powershell | Out-String | Invoke-Expression`,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletionV2(os.Stdout, true)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		default:
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/completion_helpers.go
+++ b/cmd/completion_helpers.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/AryaLabsHQ/agentree/internal/git"
+	"github.com/spf13/cobra"
+)
+
+// getBranchCompletions returns all available git branches for completion
+func getBranchCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	repo, err := git.NewRepository()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	branches, err := repo.ListBranches()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	// Filter branches that start with the toComplete string
+	var completions []string
+	for _, branch := range branches {
+		if strings.HasPrefix(branch, toComplete) {
+			completions = append(completions, branch)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// getWorktreeCompletions returns all existing worktrees for completion
+func getWorktreeCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	repo, err := git.NewRepository()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	worktrees, err := repo.ListWorktrees()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	// Extract just the directory names for easier completion
+	var completions []string
+	for _, worktree := range worktrees {
+		// Use the base name of the path for completion
+		name := filepath.Base(worktree)
+		if strings.HasPrefix(name, toComplete) {
+			completions = append(completions, name)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// Commented out for future use when agent types and config commands are implemented
+
+// // getAgentTypeCompletions returns available agent types for completion
+// func getAgentTypeCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// 	// These are placeholder agent types - will be expanded in the future
+// 	agentTypes := []string{
+// 		"claude",
+// 		"cursor",
+// 		"copilot",
+// 		"generic",
+// 	}
+
+// 	var completions []string
+// 	for _, agent := range agentTypes {
+// 		if strings.HasPrefix(agent, toComplete) {
+// 			completions = append(completions, agent)
+// 		}
+// 	}
+
+// 	return completions, cobra.ShellCompDirectiveNoFileComp
+// }
+
+// // getConfigKeyCompletions returns available configuration keys for completion
+// func getConfigKeyCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// 	// Configuration keys that can be set
+// 	configKeys := []string{
+// 		"defaultSetup",
+// 		"npmSetup",
+// 		"pnpmSetup",
+// 		"yarnSetup",
+// 		"postCreateScripts",
+// 		"env.enabled",
+// 		"env.includePatterns",
+// 		"env.excludePatterns",
+// 	}
+
+// 	var completions []string
+// 	for _, key := range configKeys {
+// 		if strings.HasPrefix(key, toComplete) {
+// 			completions = append(completions, key)
+// 		}
+// 	}
+
+// 	return completions, cobra.ShellCompDirectiveNoFileComp
+// }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -58,6 +58,10 @@ func init() {
 
 	// Make branch required unless in interactive mode
 	_ = createCmd.MarkFlagRequired("branch")
+	
+	// Register custom completion functions
+	_ = createCmd.RegisterFlagCompletionFunc("from", getBranchCompletions)
+	_ = createCmd.RegisterFlagCompletionFunc("base", getBranchCompletions)
 }
 
 // For backward compatibility, also make flags available at root level

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -22,6 +22,15 @@ Use -y to skip confirmation and force removal of dirty worktrees.
 Use -R to also delete the local branch after removing the worktree.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRemove,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Provide both branch and worktree completions
+		branches, _ := getBranchCompletions(cmd, args, toComplete)
+		worktrees, _ := getWorktreeCompletions(cmd, args, toComplete)
+		return append(branches, worktrees...), cobra.ShellCompDirectiveNoFileComp
+	},
 }
 
 var (
@@ -40,6 +49,10 @@ func init() {
 	// Define flags
 	removeCmd.Flags().BoolVarP(&force, "yes", "y", false, "Force removal without confirmation")
 	removeCmd.Flags().BoolVarP(&deleteBranch, "delete-branch", "R", false, "Also delete the local branch")
+	
+	// Copy flags to alias
+	removeAlias.Flags().BoolVarP(&force, "yes", "y", false, "Force removal without confirmation")
+	removeAlias.Flags().BoolVarP(&deleteBranch, "delete-branch", "R", false, "Also delete the local branch")
 }
 
 func runRemove(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,5 @@ func Execute() error {
 }
 
 func init() {
-	// Disable Cobra's default completion command
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	// Custom completion functions will be registered in individual command files
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -224,3 +224,25 @@ func (r *Repository) DeleteBranch(branch string) error {
 	
 	return nil
 }
+
+// ListWorktrees returns a list of all worktree paths
+func (r *Repository) ListWorktrees() ([]string, error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = r.Root
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	
+	lines := strings.Split(string(output), "\n")
+	var worktrees []string
+	
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) >= 2 && parts[0] == "worktree" {
+			worktrees = append(worktrees, parts[1])
+		}
+	}
+	
+	return worktrees, nil
+}


### PR DESCRIPTION
## Summary
- Add shell completion support for Bash, Zsh, Fish, and PowerShell
- Implement dynamic completions for branch names and worktree names
- Add `agentree completion` command to generate shell-specific scripts

## Changes
- Added `completion.go` with shell script generation command
- Added `completion_helpers.go` with dynamic completion functions
- Enhanced `git.Repository` with `ListWorktrees()` method
- Updated create and remove commands with completion functions
- Added shell completion setup documentation to README

## Test Plan
- [x] Built and tested completion generation for all shells
- [x] Verified dynamic completions work for branch names
- [x] Verified dynamic completions work for worktree names
- [x] All tests passing (`make test`)
- [x] Linting passes (`make lint`)

## Documentation
Updated README with installation instructions for each shell type.

🤖 Generated with [Claude Code](https://claude.ai/code)